### PR TITLE
Add auth to user routes

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -424,7 +424,7 @@ paths:
       tags:
         - user
       summary: Create user
-      description: This can only be done by the logged in user.
+      description: ''
       operationId: createUser
       responses:
         default:
@@ -529,6 +529,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+        - petstore_auth: []
   '/user/{username}':
     get:
       tags:
@@ -586,6 +588,8 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/User'
+      security:
+        - petstore_auth: []
     delete:
       tags:
         - user
@@ -604,6 +608,8 @@ paths:
           description: Invalid username supplied
         '404':
           description: User not found
+      security:
+        - petstore_auth: []
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'


### PR DESCRIPTION
Removed the description on createUser that said only a logged in user can create a user. 
Added auth with no required scopes to log out, update user, and delete user. 

It's not clear to me how security is supposed to work across the API, but these things should at least make it more consistent and sensical. I made a guess that createUser would fill the role of signing up, but it could just as easily been intended to keep the description and make it so that only a logged in user can create another user.   
Requiring a token to log out makes sense, because you'd have to be logged in first.   
Requiring a token to update and delete user makes the security consistent with the operation description.