### PR TITLE
Return 400 instead of 405 for invalid input

### DIFF
--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -50,7 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
-        '405':
+        '400':
           description: Invalid input
       security:
         - petstore_auth:
@@ -86,11 +86,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pet'
         '400':
-          description: Invalid ID supplied
+          description: Validation exception
         '404':
           description: Pet not found
-        '405':
-          description: Validation exception
       security:
         - petstore_auth:
             - 'write:pets'
@@ -246,7 +244,7 @@ paths:
           schema:
             type: string
       responses:
-        '405':
+        '400':
           description: Invalid input
       security:
         - petstore_auth:
@@ -352,7 +350,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
-        '405':
+        '400':
           description: Invalid input
       requestBody:
         content:


### PR DESCRIPTION
405 is "Method Not Allowed" which seems unlikely to be what we want. A generic 400 "Bad Request" seems like a better status for our documented message of "Invalid input".

I was also inclined to combine some of these 400 "Invalid ID supplied" statuses into the 404s defined for the same method, but I understand that the 400 is probably meant to say "you passed a non-int id, so I'm not going to bother looking for your resource" as opposed to "I looked for your resource but couldn't find it".